### PR TITLE
Code hygiene: typo fixes, brew cask migration, VSCode automation, docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
-.PHONY: git
+.PHONY: all bash brew projects_brew ssh git screenshots vscode_extentions debug help
+
 default: help
+
 help:
 	@echo "Available targets:"
-	@echo "  make screenshots:   configure screenshots folder"
-	@echo "  make brew: 	     install all brew repositories, packages, casks"
-	@echo "  make projects_brew: install only projects-based brew repos, packages, casks"
-
-.PHONY: screenshots brew projects_brew ssh bash debug
+	@echo "  make all               run the full playbook"
+	@echo "  make bash              configure bash environment (dotfiles, symlinks)"
+	@echo "  make brew              install all brew repositories, packages, and casks"
+	@echo "  make projects_brew     install project-specific brew repos, packages, and casks"
+	@echo "  make ssh               configure SSH (~/.ssh/config)"
+	@echo "  make git               configure git dotfiles"
+	@echo "  make screenshots       set macOS screenshot save folder"
+	@echo "  make vscode_extentions install/uninstall VSCode extensions"
+	@echo "  make debug             list all available playbook tags"
 
 all:
 	./playbook-init.yml
@@ -15,9 +21,6 @@ all:
 bash:
 	./playbook-init.yml --tags bash
 	@bash -l -i -c 'notify "bash is done" "pimp-my-mac"'
-
-screenshots:
-	./playbook-init.yml --tags macos_defaults --skip-tags always
 
 brew:
 	./playbook-init.yml --tags brew
@@ -31,10 +34,17 @@ ssh:
 	./playbook-init.yml --tags ssh_config
 	@bash -l -i -c 'notify "SSH config is done" "pimp-my-mac"'
 
-debug:
-	./playbook-init.yml --list-tags
-	@bash -l -i -c 'notify "debug is done" "pimp-my-mac"'
-
 git:
 	./playbook-init.yml --tags git
 	@bash -l -i -c 'notify "git is done" "pimp-my-mac"'
+
+screenshots:
+	./playbook-init.yml --tags macos_defaults --skip-tags always
+
+vscode_extentions:
+	./playbook-init.yml --tags vscode_extentions
+	@bash -l -i -c 'notify "VSCode extensions done" "pimp-my-mac"'
+
+debug:
+	./playbook-init.yml --list-tags
+	@bash -l -i -c 'notify "debug is done" "pimp-my-mac"'

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ git:
 	@bash -l -i -c 'notify "git is done" "pimp-my-mac"'
 
 screenshots:
+	# --skip-tags always suppresses project-discovery overhead for this lightweight one-shot target
 	./playbook-init.yml --tags macos_defaults --skip-tags always
 
 vscode_extentions:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all bash brew projects_brew ssh git screenshots vscode_extentions debug help
+.PHONY: all bash brew projects_brew ssh git screenshots vscode_extensions debug help
 
 default: help
 
@@ -11,7 +11,7 @@ help:
 	@echo "  make ssh               configure SSH (~/.ssh/config)"
 	@echo "  make git               configure git dotfiles"
 	@echo "  make screenshots       set macOS screenshot save folder"
-	@echo "  make vscode_extentions install/uninstall VSCode extensions"
+	@echo "  make vscode_extensions install/uninstall VSCode extensions"
 	@echo "  make debug             list all available playbook tags"
 
 all:
@@ -42,8 +42,8 @@ screenshots:
 	# --skip-tags always suppresses project-discovery overhead for this lightweight one-shot target
 	./playbook-init.yml --tags macos_defaults --skip-tags always
 
-vscode_extentions:
-	./playbook-init.yml --tags vscode_extentions
+vscode_extensions:
+	./playbook-init.yml --tags vscode_extensions
 	@bash -l -i -c 'notify "VSCode extensions done" "pimp-my-mac"'
 
 debug:

--- a/README.md
+++ b/README.md
@@ -16,26 +16,56 @@ Run this command in your terminal
 mkdir -p ~/develop/com.github/disfinder/pimp-my-mac/ && cd "$_" && git clone https://github.com/disfinder/pimp-my-mac.git .
 ```
 
-### custom settings
+### Custom settings — the projects/ pattern
 
-Playbook will search for anything inside `projects` folder and process discovered data.
-Multiproject configuration support:
+The `projects/` directory lets you maintain per-context configuration alongside the
+main playbook without forking it. Each subdirectory of `projects/` is a **project**.
 
-- git configuration
-- bash configuration
-- variable configuration
-- ssh configuration
+The playbook discovers projects automatically — no registration required. Just create
+a directory and populate whichever files you need.
 
-`projects/PROJECTNAME/project_vars.yaml` must list git includedirs, if gitconfig usage is expected for the project:
+#### Files a project can provide
+
+| File                | Purpose                                                                      |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `project_vars.yaml` | Variables: brew packages, brew casks, brew repositories, git includeif paths |
+| `gitconfig`         | Git identity and settings for this project's directories                     |
+| `project.bashrc`    | Shell customisations sourced after the main bash profile                     |
+| `ssh_config`        | SSH host entries merged into `~/.ssh/config`                                 |
+
+All files are optional. A project with only `project_vars.yaml` is valid.
+
+#### `project_vars.yaml` schema
 
 ```yaml
+# Routes git identity to specific working directories.
+# The trailing / on dir: values is required by git's includeIf directive.
 git_includeif:
   - dir:  ~/develop/com.github/PROJECTNAME/
     path: ~/opt/dotfiles/projects/PROJECTNAME/gitconfig
+
+# Optional brew additions — merged with all other projects before installation.
+brew_repositories: []
+brew_packages:
+  - some-tool
+brew_casks:
+  - some-app
+```
+
+#### Minimal example
+
+```
+projects/
+└── mywork/
+    ├── project_vars.yaml   # sets git_includeif + brew_packages
+    ├── gitconfig           # name/email for work commits
+    ├── project.bashrc      # work-specific aliases
+    └── ssh_config          # SSH hosts for work servers
 ```
 
 > [!WARNING]
-> `/` at the path's end is crucial for `dir:` value.
+> The trailing `/` on every `dir:` value under `git_includeif` is required.
+> Without it git's `includeIf` will not activate for that directory.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pimp my Mac
 
-Ansible playbook for consistent yet flexible congfiguration of your Mac machines.
+Ansible playbook for consistent yet flexible configuration of your Mac machines.
 
 ## Prerequisites
 

--- a/docs/plans/2026-02-20-code-hygiene-design.md
+++ b/docs/plans/2026-02-20-code-hygiene-design.md
@@ -1,0 +1,133 @@
+# Code Hygiene Design
+
+**Date:** 2026-02-20
+**Scope:** Typo fixes, hardcoded paths, DMG → brew cask migration, VSCode extension automation, Makefile improvements, documentation.
+
+## Goals
+
+- Fix spelling mistakes in variable names, tags, and documentation.
+- Replace hardcoded user paths with portable equivalents.
+- Replace the dead `dmg_files`/`applications` mechanism with brew casks.
+- Automate VSCode extension installation via Ansible.
+- Make `make help` accurate and complete.
+- Improve README and add inline comments for new adopters.
+
+## Out of Scope
+
+- Ansible roles (monolithic design is intentional).
+- zsh support.
+- macOS defaults expansion.
+- Version pinning for brew packages.
+
+---
+
+## Section 1: Typo and Variable Name Fixes
+
+| File | Current | Fixed |
+|---|---|---|
+| `playbook-init.yml` (var + `failed_when` references) | `ignore_brew_erorrs` | `ignore_brew_errors` |
+| `playbook-init.yml` (tag on brew_casks task) | `brew_cascs` | `brew_casks` |
+| `README.md` | `congfiguration` | `configuration` |
+| `projects/personal/README.md` | `projec-related` | `project-related` |
+
+Note: `vscode_extentions` spelling is retained intentionally for consistency with existing tags.
+
+---
+
+## Section 2: DMG Files and Applications → Brew Casks
+
+All entries in `dmg_files` and `applications` are available as Homebrew casks. No download machinery needed.
+
+### Mapping
+
+| Old entry | Destination | Brew cask |
+|---|---|---|
+| Telegram | `projects/personal/project_vars.yaml` brew_casks | `telegram` |
+| TeamViewer | `projects/personal/project_vars.yaml` brew_casks | `teamviewer` |
+| VOX | `projects/personal/project_vars.yaml` brew_casks | `vox` |
+| Choosy | `projects/personal/project_vars.yaml` brew_casks | `choosy` |
+| CheatSheet (commented) | replace with free alternative | `keyclu` |
+| Krita | already in `projects/personal` | no change |
+| IntelliJ IDEA CE | already in `projects/personal` | no change |
+
+CheatSheet stopped working on macOS 14 Sonoma. KeyClu is its free, actively maintained replacement (brew cask: `keyclu`).
+
+### Removals from `playbook-init.yml`
+
+- `dmg_files` variable block.
+- `applications` variable block.
+- "Download applications" task (was tagged `never`).
+- "Download dmg_files" task (was tagged `never`).
+
+---
+
+## Section 3: Hardcoded User Paths
+
+Two files reference `/Users/disfinder/` directly, breaking portability when adopted by another user.
+
+| File | Replace with |
+|---|---|
+| `bash/bash.bashrc` (Python PATH additions) | `$HOME` |
+| `projects/personal/project.bashrc` (iTerm2 integration) | `$HOME` |
+
+---
+
+## Section 4: VSCode Extension Installation
+
+Add an Ansible task block to install/uninstall extensions using the `code` CLI, which ships with VSCode.
+
+```yaml
+- name: Install VSCode extensions
+  tags: vscode_extentions
+  block:
+    - name: Install enabled extensions
+      command: "code --install-extension {{ item }}"
+      loop: "{{ vscode_extentions }}"
+      ignore_errors: yes
+
+    - name: Uninstall disabled extensions
+      command: "code --uninstall-extension {{ item }}"
+      loop: "{{ vscode_extentions_disabled }}"
+      ignore_errors: yes
+```
+
+`ignore_errors: yes` is appropriate here because `code` returns non-zero for already-installed or already-absent extensions.
+
+---
+
+## Section 5: Makefile Improvements
+
+Current `make help` only lists 3 of 8 targets. Update to list all targets with aligned descriptions, and add the new `vscode_extentions` target.
+
+Targets after change: `all`, `bash`, `brew`, `projects_brew`, `ssh`, `git`, `screenshots`, `vscode_extentions`, `debug`.
+
+---
+
+## Section 6: README and Inline Comments
+
+### README additions
+
+Add a **Projects pattern** section covering:
+- What the `projects/` directory is for.
+- Which files a project can contain (`project_vars.yaml`, `gitconfig`, `project.bashrc`, `ssh_config`).
+- The `project_vars.yaml` schema (supported keys: `git_includeif`, `brew_packages`, `brew_casks`, `brew_repositories`).
+- How `git_includeif` routes git identity by working directory.
+- A minimal example project.
+
+### Inline comments in `playbook-init.yml`
+
+- `ignore_brew_errors`: explain why it is `yes` (brew exits non-zero for already-installed packages).
+- `never` tag convention: explain that tasks tagged `never` are opt-in and must be called explicitly.
+- ansible-vault diff block: link to the README note explaining the `.gitattributes` requirement.
+- Project discovery block: short comment explaining the find → set_fact → include_vars chain.
+- `vscode_extentions` block: note that VSCode must already be installed (`brew_casks` runs first).
+
+---
+
+## Acceptance Criteria
+
+- [ ] `ansible-lint` passes with no new warnings.
+- [ ] `make help` lists every target.
+- [ ] `make vscode_extentions` installs all extensions on a machine with VSCode present.
+- [ ] No occurrences of `/Users/disfinder/` outside of `projects/` content files.
+- [ ] No occurrences of `dmg_files` or `applications` variables in `playbook-init.yml`.

--- a/docs/plans/2026-02-20-code-hygiene.md
+++ b/docs/plans/2026-02-20-code-hygiene.md
@@ -1,0 +1,585 @@
+# Code Hygiene Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix typos, remove dead code, replace DMG installs with brew casks, automate VSCode extension management, and improve Makefile and README for easier onboarding.
+
+**Architecture:** All changes are confined to existing files — no new modules or roles. The monolithic playbook structure is intentional and preserved. Verification after each task uses `ansible-lint`.
+
+**Tech Stack:** Ansible, Homebrew, bash, Make.
+
+---
+
+### Task 1: Fix typos in `playbook-init.yml`
+
+**Files:**
+- Modify: `playbook-init.yml` (lines 10, 200, 209, 331, 347, 348)
+
+**Step 1: Run ansible-lint to capture baseline**
+
+```bash
+ansible-lint playbook-init.yml
+```
+
+Expected: some warnings, note the count. This is your before snapshot.
+
+**Step 2: Fix `ignore_brew_erorrs` — variable declaration**
+
+In `playbook-init.yml` line 10, change:
+```yaml
+    - ignore_brew_erorrs: yes
+```
+to:
+```yaml
+    # Set to `yes` so brew tasks do not abort the run for already-installed packages;
+    # brew exits non-zero in that case, which would otherwise be treated as a failure.
+    - ignore_brew_errors: yes
+```
+
+**Step 3: Fix `ignore_brew_erorrs` — all usages**
+
+Replace every remaining occurrence of `ignore_brew_erorrs` with `ignore_brew_errors`.
+There are four more: lines 200, 209, 331, 348.
+
+```yaml
+# line 200 — brew packages task
+      failed_when: not ignore_brew_errors
+
+# line 209 — brew casks task
+      failed_when: not ignore_brew_errors
+
+# line 331 — project brew packages
+          failed_when: not ignore_brew_errors # do not fail
+
+# line 348 — project brew casks
+          failed_when: not ignore_brew_errors # do not fail
+```
+
+**Step 4: Fix `brew_cascs` tag**
+
+Line 347, change:
+```yaml
+          tags: projects_brew_cascs
+```
+to:
+```yaml
+          tags: projects_brew_casks
+```
+
+**Step 5: Run ansible-lint**
+
+```bash
+ansible-lint playbook-init.yml
+```
+
+Expected: same or fewer warnings than baseline — no new ones.
+
+**Step 6: Commit**
+
+```bash
+git add playbook-init.yml
+git commit -m "fix: correct typos ignore_brew_errors and brew_casks tag"
+```
+
+---
+
+### Task 2: Fix typos in documentation files
+
+**Files:**
+- Modify: `README.md` (line 3)
+- Modify: `projects/personal/README.md` (line 1 or wherever "projec-related" appears)
+
+**Step 1: Fix `README.md`**
+
+Line 3, change:
+```
+Ansible playbook for consistent yet flexible congfiguration of your Mac machines.
+```
+to:
+```
+Ansible playbook for consistent yet flexible configuration of your Mac machines.
+```
+
+**Step 2: Fix `projects/personal/README.md`**
+
+Change:
+```
+projec-related
+```
+to:
+```
+project-related
+```
+
+**Step 3: Commit**
+
+```bash
+git add README.md projects/personal/README.md
+git commit -m "fix: correct spelling in README files"
+```
+
+---
+
+### Task 3: Fix hardcoded `/Users/disfinder/` paths
+
+**Files:**
+- Modify: `projects/personal/project.bashrc` (lines 21–22, comments on 30–32)
+
+**Step 1: Fix SDKMAN lines**
+
+Lines 21–22, change:
+```bash
+export SDKMAN_DIR="/Users/disfinder/.sdkman"
+[[ -s "/Users/disfinder/.sdkman/bin/sdkman-init.sh" ]] && source "/Users/disfinder/.sdkman/bin/sdkman-init.sh"
+```
+to:
+```bash
+export SDKMAN_DIR="$HOME/.sdkman"
+[[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"
+```
+
+**Step 2: Clean up stale iTerm2 comments**
+
+Lines 29–33 contain an auto-generated comment block left over from the iTerm2 shell integration installer. It references `/Users/disfinder/` in a comment and is no longer informative. Remove lines 29–33:
+
+```bash
+# To make it work right now, do:
+#   source /Users/disfinder/.iterm2_shell_integration.bash
+
+# This line was also added to /Users/disfinder/.bash_profile, so the next time you log in it will be loaded automatically.
+```
+
+The `test -e "${HOME}/.iterm2_shell_integration.bash"` line above it already handles the integration correctly and can stay.
+
+**Step 3: Commit**
+
+```bash
+git add projects/personal/project.bashrc
+git commit -m "fix: replace hardcoded home path with \$HOME"
+```
+
+---
+
+### Task 4: Migrate DMG and application entries to brew casks
+
+All five apps previously listed under `dmg_files` and `applications` are available as Homebrew casks. CheatSheet no longer works on macOS 14+ Sonoma; its free replacement is KeyClu.
+
+**Files:**
+- Modify: `projects/personal/project_vars.yaml`
+
+**Step 1: Add casks to personal project**
+
+In `projects/personal/project_vars.yaml`, the current `brew_casks` block is:
+```yaml
+brew_casks:
+  - intellij-idea-ce
+  - krita
+  - pycharm-ce
+```
+
+Replace with:
+```yaml
+brew_casks:
+  - choosy
+  - intellij-idea-ce
+  - keyclu      # replacement for CheatSheet (discontinued, broken on macOS 14+)
+  - krita
+  - pycharm-ce
+  - teamviewer
+  - telegram
+  - vox
+```
+
+**Step 2: Commit**
+
+```bash
+git add projects/personal/project_vars.yaml
+git commit -m "feat: migrate dmg/app installs to brew casks in personal project"
+```
+
+---
+
+### Task 5: Remove dead `dmg_files` and `applications` blocks from playbook
+
+**Files:**
+- Modify: `playbook-init.yml`
+
+**Step 1: Remove the `dmg_files` variable block**
+
+Find and remove the entire block (currently lines 92–102):
+```yaml
+    - dmg_files:
+        - name: Idea
+          url: https://download.jetbrains.com/idea/ideaIC-2019.3.4-jbr8.dmg
+          filename: ideaIC-2019.3.4-jbr8.dmg
+        - name: Telegram
+          url: https://telegram.org/dl/desktop/mac
+          filename: telegram_latest.dmg
+        - name: teamviewer
+        - name: VOX
+        - name: krita
+          website: https://krita.org/en/
+```
+
+**Step 2: Remove the `applications` variable block**
+
+Find and remove the entire block (currently lines 103–110):
+```yaml
+    - applications:
+        # - name: CheatSheet
+        #   url: https://www.mediaatelier.com/CheatSheet/
+        #   filename: tbd
+        # application gone, replacement needed
+        - name: Choosy
+          url: https://choosy.app/
+          filename: tbd
+```
+
+**Step 3: Remove the two download tasks**
+
+Find and remove the "Download applications" task block:
+```yaml
+    - name: Download applications
+      tags: never
+      get_url:
+        url: "{{ item.url }}"
+        dest: "{{ temp_folder }}/{{ item.filename }}"
+      loop: "{{ applications }}"
+      loop_control:
+        label: "{{ item.name }}"
+```
+
+Find and remove the "Download dmg_files" task block:
+```yaml
+    - name: Download dmg_files
+      tags: never
+      get_url:
+        url: "{{ item.url }}"
+        dest: "{{ temp_folder }}/{{ item.filename }}"
+      loop: "{{ dmg_files }}"
+      loop_control:
+        label: "{{ item.name }}"
+```
+
+**Step 4: Run ansible-lint**
+
+```bash
+ansible-lint playbook-init.yml
+```
+
+Expected: no errors referencing `dmg_files` or `applications`.
+
+**Step 5: Commit**
+
+```bash
+git add playbook-init.yml
+git commit -m "refactor: remove dead dmg_files and applications blocks"
+```
+
+---
+
+### Task 6: Add VSCode extension installation task
+
+**Files:**
+- Modify: `playbook-init.yml`
+
+**Step 1: Add the task block**
+
+After the "Configure GitHub cli" task block (near the end of the playbook), add:
+
+```yaml
+    - name: Manage VSCode extensions
+      # Requires VSCode to already be installed (brew_casks runs first under the brew tag).
+      # `ignore_errors` is needed because `code` exits non-zero for already-installed
+      # or already-absent extensions, which would otherwise abort the play.
+      tags: vscode_extentions
+      block:
+        - name: Install enabled VSCode extensions
+          command: "code --install-extension {{ item }}"
+          loop: "{{ vscode_extentions }}"
+          ignore_errors: yes
+
+        - name: Uninstall disabled VSCode extensions
+          command: "code --uninstall-extension {{ item }}"
+          loop: "{{ vscode_extentions_disabled }}"
+          ignore_errors: yes
+```
+
+**Step 2: Run ansible-lint**
+
+```bash
+ansible-lint playbook-init.yml
+```
+
+Expected: no new warnings.
+
+**Step 3: Commit**
+
+```bash
+git add playbook-init.yml
+git commit -m "feat: automate VSCode extension install/uninstall via ansible"
+```
+
+---
+
+### Task 7: Add inline comments to non-obvious playbook sections
+
+**Files:**
+- Modify: `playbook-init.yml`
+
+**Step 1: Comment the `never` tag convention above the debug3 task**
+
+Find the "Debug projects data" task (currently around line 276):
+```yaml
+    - name: Debug projects data
+      tags:
+        - never
+        - debug3
+```
+
+Add a comment immediately above it:
+```yaml
+    # Tasks tagged `never` are opt-in: they do not run during a normal play.
+    # To invoke them explicitly: ./playbook-init.yml --tags debug3
+    - name: Debug projects data
+      tags:
+        - never
+        - debug3
+```
+
+**Step 2: Comment the project discovery chain**
+
+Find the "Collect projects folders" task (currently around line 222):
+```yaml
+    - name: Collect projects folders
+```
+
+Add a comment block immediately above it:
+```yaml
+    # --- Project discovery ---
+    # Projects are self-contained directories under projects/.
+    # Each project can provide: project_vars.yaml, gitconfig, project.bashrc, ssh_config.
+    # The three tasks below wire them up:
+    #   1. find discovers project directories.
+    #   2. set_fact builds a list of dicts with per-project file paths.
+    #   3. include_vars loads each project_vars.yaml into a namespaced variable.
+    # Downstream tasks then look up those vars by project name.
+    - name: Collect projects folders
+```
+
+**Step 3: Commit**
+
+```bash
+git add playbook-init.yml
+git commit -m "docs: add inline comments for non-obvious playbook sections"
+```
+
+---
+
+### Task 8: Update Makefile
+
+**Files:**
+- Modify: `Makefile`
+
+**Step 1: Rewrite the Makefile**
+
+Replace the entire file with:
+
+```makefile
+.PHONY: all bash brew projects_brew ssh git screenshots vscode_extentions debug help
+
+default: help
+
+help:
+	@echo "Available targets:"
+	@echo "  make all              run the full playbook"
+	@echo "  make bash             configure bash environment (dotfiles, symlinks)"
+	@echo "  make brew             install all brew repositories, packages, and casks"
+	@echo "  make projects_brew    install project-specific brew repos, packages, and casks"
+	@echo "  make ssh              configure SSH (~/.ssh/config)"
+	@echo "  make git              configure git dotfiles"
+	@echo "  make screenshots      set macOS screenshot save folder"
+	@echo "  make vscode_extentions install/uninstall VSCode extensions"
+	@echo "  make debug            list all available playbook tags"
+
+all:
+	./playbook-init.yml
+	@bash -l -i -c 'notify "ALL is done" "pimp-my-mac"'
+
+bash:
+	./playbook-init.yml --tags bash
+	@bash -l -i -c 'notify "bash is done" "pimp-my-mac"'
+
+brew:
+	./playbook-init.yml --tags brew
+	@bash -l -i -c 'notify "brew is done" "pimp-my-mac"'
+
+projects_brew:
+	./playbook-init.yml --tags projects_brew
+	@bash -l -i -c 'notify "projects brew is done" "pimp-my-mac"'
+
+ssh:
+	./playbook-init.yml --tags ssh_config
+	@bash -l -i -c 'notify "SSH config is done" "pimp-my-mac"'
+
+git:
+	./playbook-init.yml --tags git
+	@bash -l -i -c 'notify "git is done" "pimp-my-mac"'
+
+screenshots:
+	./playbook-init.yml --tags macos_defaults --skip-tags always
+
+vscode_extentions:
+	./playbook-init.yml --tags vscode_extentions
+	@bash -l -i -c 'notify "VSCode extensions done" "pimp-my-mac"'
+
+debug:
+	./playbook-init.yml --list-tags
+	@bash -l -i -c 'notify "debug is done" "pimp-my-mac"'
+```
+
+**Step 2: Verify make help output**
+
+```bash
+make help
+```
+
+Expected output:
+```
+Available targets:
+  make all              run the full playbook
+  make bash             configure bash environment (dotfiles, symlinks)
+  make brew             install all brew repositories, packages, and casks
+  make projects_brew    install project-specific brew repos, packages, and casks
+  make ssh              configure SSH (~/.ssh/config)
+  make git              configure git dotfiles
+  make screenshots      set macOS screenshot save folder
+  make vscode_extentions install/uninstall VSCode extensions
+  make debug            list all available playbook tags
+```
+
+**Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "feat: update Makefile with all targets and vscode_extentions target"
+```
+
+---
+
+### Task 9: Expand README with Projects pattern section
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Replace the "custom settings" section**
+
+Find the current `### custom settings` section and replace it with the expanded version below. This keeps all existing content and adds the projects schema, git_includeif explanation, and a minimal example.
+
+Replace:
+```markdown
+### custom settings
+
+Playbook will search for anything inside `projects` folder and process discovered data.
+Multiproject configuration support:
+
+- git configuration
+- bash configuration
+- variable configuration
+- ssh configuration
+
+`projects/PROJECTNAME/project_vars.yaml` must list git includedirs, if gitconfig usage is expected for the project:
+
+```yaml
+git_includeif:
+  - dir:  ~/develop/com.github/PROJECTNAME/
+    path: ~/opt/dotfiles/projects/PROJECTNAME/gitconfig
+```
+
+> [!WARNING]
+> `/` at the path's end is crucial for `dir:` value.
+```
+
+With:
+```markdown
+### Custom settings — the projects/ pattern
+
+The `projects/` directory lets you maintain per-context configuration alongside the
+main playbook without forking it. Each subdirectory of `projects/` is a **project**.
+
+The playbook discovers projects automatically — no registration required. Just create
+a directory and populate whichever files you need.
+
+#### Files a project can provide
+
+| File | Purpose |
+|---|---|
+| `project_vars.yaml` | Variables: brew packages, brew casks, brew repos, git includeif paths |
+| `gitconfig` | Git identity and settings for this project's directories |
+| `project.bashrc` | Shell customisations sourced after the main bash profile |
+| `ssh_config` | SSH host entries merged into `~/.ssh/config` |
+
+All files are optional. A project with only `project_vars.yaml` is valid.
+
+#### `project_vars.yaml` schema
+
+```yaml
+# Routes git identity to specific working directories.
+# The trailing / on dir: values is required by git's includeIf directive.
+git_includeif:
+  - dir:  ~/develop/com.github/PROJECTNAME/
+    path: ~/opt/dotfiles/projects/PROJECTNAME/gitconfig
+
+# Optional brew additions — merged with all other projects before installation.
+brew_repositories: []
+brew_packages:
+  - some-tool
+brew_casks:
+  - some-app
+```
+
+#### Minimal example
+
+```
+projects/
+└── mywork/
+    ├── project_vars.yaml   # sets git_includeif + brew_packages
+    ├── gitconfig           # name/email for work commits
+    ├── project.bashrc      # work-specific aliases
+    └── ssh_config          # SSH hosts for work servers
+```
+
+> [!WARNING]
+> The trailing `/` on every `dir:` value under `git_includeif` is required.
+> Without it git's `includeIf` will not activate for that directory.
+```
+
+**Step 2: Run a quick sanity check**
+
+```bash
+grep -n "congfiguration\|projec-related\|/Users/disfinder" README.md projects/personal/README.md
+```
+
+Expected: no output (all fixed instances from earlier tasks are gone).
+
+**Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: expand README with projects/ pattern reference"
+```
+
+---
+
+### Final verification
+
+```bash
+ansible-lint playbook-init.yml
+make help
+grep -rn "/Users/disfinder/" bash/ projects/
+```
+
+Expected:
+- `ansible-lint`: no errors, warnings same or fewer than baseline.
+- `make help`: lists all 9 targets.
+- `grep`: no output (no remaining hardcoded home paths in templated files).

--- a/playbook-init.yml
+++ b/playbook-init.yml
@@ -91,7 +91,7 @@
         - visual-studio-code
         - dozer
         - jordanbaird-ice
-    - vscode_extentions:
+    - vscode_extensions:
         - aaron-bond.better-comments
         - adammaras.overtype
         - andyyaldoo.vscode-json # unescape/format json
@@ -122,7 +122,7 @@
         - timonwong.ansible-autocomplete
         - wholroyd.jinja
         - yzhang.markdown-all-in-one
-    - vscode_extentions_disabled:
+    - vscode_extensions_disabled:
         - freakone.cursoruler
         - geeebe.duplicate
         - james-yu.latex-workshop
@@ -500,14 +500,14 @@
       # Requires VSCode to already be installed (brew_casks runs first under the brew tag).
       # `ignore_errors` is needed because `code` exits non-zero for already-installed
       # or already-absent extensions, which would otherwise abort the play.
-      tags: vscode_extentions
+      tags: vscode_extensions
       block:
         - name: Install enabled VSCode extensions
           command: "code --install-extension {{ item }}"
-          loop: "{{ vscode_extentions }}"
+          loop: "{{ vscode_extensions }}"
           ignore_errors: yes
 
         - name: Uninstall disabled VSCode extensions
           command: "code --uninstall-extension {{ item }}"
-          loop: "{{ vscode_extentions_disabled }}"
+          loop: "{{ vscode_extensions_disabled }}"
           ignore_errors: yes

--- a/playbook-init.yml
+++ b/playbook-init.yml
@@ -485,3 +485,19 @@
         src: "gh/config.yml"
         dest: ~/.config/gh/config.yml
         mode: '600'
+
+    - name: Manage VSCode extensions
+      # Requires VSCode to already be installed (brew_casks runs first under the brew tag).
+      # `ignore_errors` is needed because `code` exits non-zero for already-installed
+      # or already-absent extensions, which would otherwise abort the play.
+      tags: vscode_extentions
+      block:
+        - name: Install enabled VSCode extensions
+          command: "code --install-extension {{ item }}"
+          loop: "{{ vscode_extentions }}"
+          ignore_errors: yes
+
+        - name: Uninstall disabled VSCode extensions
+          command: "code --uninstall-extension {{ item }}"
+          loop: "{{ vscode_extentions_disabled }}"
+          ignore_errors: yes

--- a/playbook-init.yml
+++ b/playbook-init.yml
@@ -7,7 +7,9 @@
   vars_files:
     - "arch/{{ ansible_architecture }}.yaml"
   vars:
-    - ignore_brew_erorrs: yes
+    # Set to `yes` so brew tasks do not abort the run for already-installed packages;
+    # brew exits non-zero in that case, which would otherwise be treated as a failure.
+    - ignore_brew_errors: yes
     - current_user: "{{ lookup('env', 'USER') }}"
     - temp_folder: "/tmp/pimp_my_temp"
     - dotfiles_folder: "~/opt/dotfiles"
@@ -197,7 +199,7 @@
       with_items: "{{ brew_repositories }}"
     - name: Setup needed brew packages
       tags: brew
-      failed_when: not ignore_brew_erorrs
+      failed_when: not ignore_brew_errors
       homebrew:
         name: "{{ item }}"
         state: present
@@ -206,7 +208,7 @@
       tags:
         - brew
         - brew_casks
-      failed_when: not ignore_brew_erorrs
+      failed_when: not ignore_brew_errors
       homebrew_cask:
         name: "{{ item }}"
         state: present
@@ -328,7 +330,7 @@
 
         - name: Setup project-related brew packages II
           tags: projects_brew_packages
-          failed_when: not ignore_brew_erorrs # do not fail
+          failed_when: not ignore_brew_errors # do not fail
           homebrew:
             name: "{{ item }}"
             state: present
@@ -344,8 +346,8 @@
             label: "{{ item.name }}"
 
         - name: Setup project-related brew brew_casks
-          tags: projects_brew_cascs
-          failed_when: not ignore_brew_erorrs # do not fail
+          tags: projects_brew_casks
+          failed_when: not ignore_brew_errors # do not fail
           homebrew_cask:
             name: "{{ item }}"
             state: present

--- a/playbook-init.yml
+++ b/playbook-init.yml
@@ -202,6 +202,14 @@
         state: present
       with_items: "{{ pip3_packages }}"
 
+    # --- Project discovery ---
+    # Projects are self-contained directories under projects/.
+    # Each project can provide: project_vars.yaml, gitconfig, project.bashrc, ssh_config.
+    # The three tasks below wire them up:
+    #   1. find discovers project directories.
+    #   2. set_fact builds a list of dicts with per-project file paths.
+    #   3. include_vars loads each project_vars.yaml into a namespaced variable.
+    # Downstream tasks then look up those vars by project name.
     - name: Collect projects folders
       tags:
         - always
@@ -256,6 +264,8 @@
       loop: "{{ projects_data }}"
       loop_control:
         label: "{{ item.name }}"
+    # Tasks tagged `never` are opt-in and do not run during a normal play.
+    # To invoke them explicitly: ./playbook-init.yml --tags debug3
     - name: Debug projects data
       tags:
         - never

--- a/playbook-init.yml
+++ b/playbook-init.yml
@@ -9,146 +9,146 @@
   vars:
     # Set to `yes` so brew tasks do not abort the run for already-installed packages;
     # brew exits non-zero in that case, which would otherwise be treated as a failure.
-    - ignore_brew_errors: yes
-    - current_user: "{{ lookup('env', 'USER') }}"
-    - temp_folder: "/tmp/pimp_my_temp"
-    - dotfiles_folder: "~/opt/dotfiles"
-    - pip3_packages:
-        - PyYAML
-        - tldr
-        # - localstack
-    - brew_repositories:
-        - homebrew/cask-fonts
-    - brew_packages:
-        - ansible-lint
-        - autojump
-        - awscli
-        - bash
-        - fzf
-        - bash-completion
-        - bash-git-prompt
-        # - ccze   # have to comment since this package is gone
-        - coreutils
-        - docker-completion
-        # - docker-compose-completion # gone
-        - gh
-        - git
-        - gpg
-        - gradle-completion
-        - grc
-        - htop
-        - httpie
-        - jq
-        - k9s
-        - lynx
-        - maven
-        - maven-completion
-        - mc
-        - mdp
-        - micro
-        - most
-        - mtr
-        - nano
-        - ncdu
-        - nmap
-        - pip-completion
-        - pv
-        - tree
-        - watch
-        - wget
-        - yq
-        - diff-so-fancy
-        - hidetatz/tap/kubecolor
-        - bat
-        - exa
-        - lazygit
-        - lsd
-        - duf
-        - dust
-        - rs/tap/curlie
-        - eksctl
-        - pinentry-mac
-        - minikube
-        - rsync
-        - helm
-        - terraform
-        - jless
-        - ffmpeg
-        - glow
-        - tmux
-        - gnu-tar
-        - go
-        # - copyq
-        - kubectx
-        - moreutils # sponge is needed
-    - brew_casks:
-        # - vagrant # do not need vagrant anymore
-        - font-hack-nerd-font
-        - firefox
-        - apptivate
-        - iterm2
-        - sourcetree
-        - visual-studio-code
-        - dozer
-        - jordanbaird-ice
-    - vscode_extensions:
-        - aaron-bond.better-comments
-        - adammaras.overtype
-        - andyyaldoo.vscode-json # unescape/format json
-        - chrmarti.ssh
-        - coolbear.systemd-unit-file
-        - devmike.mikrotik-routeros-script
-        - efanzh.graphviz-preview
-        - esbenp.prettier-vscode
-        - fabiospampinato.vscode-todo-plus
-        - haaaad.ansible
-        - hashicorp.terraform
-        - hoovercj.vscode-power-mode
-        - kelvin.vscode-sshfs
-        - lamartire.git-indicators
-        - leodevbro.blockman
-        - marcostazi.vs-code-vagrantfile
-        - mrmlnc.vscode-apache
-        - mrmlnc.vscode-duplicate
-        - ms-azuretools.vscode-docker
-        - ms-kubernetes-tools.vscode-kubernetes-tools
-        - nobuhito.printcode
-        - qinjia.filenamecomplete
-        - redhat.vscode-yaml
-        - samverschueren.final-newline
-        - shanoor.vscode-nginx
-        - shardulm94.trailing-spaces
-        - stephanvs.dot
-        - timonwong.ansible-autocomplete
-        - wholroyd.jinja
-        - yzhang.markdown-all-in-one
-    - vscode_extensions_disabled:
-        - freakone.cursoruler
-        - geeebe.duplicate
-        - james-yu.latex-workshop
-    - bash_dotfiles:
-        - template: bash/bash.bashrc
-          filename: "{{ dotfiles_folder }}/.bash_profile"
-          linkname: "~/.bash_profile"
-        - template: bash/grc.bashrc
-          filename: "{{ dotfiles_folder }}/grc.bashrc"
-          linkname: "~/.grc.bashrc"
-        - template: bash/inputrc.bashrc
-          filename: "{{ dotfiles_folder }}/.inputrc"
-          linkname: "~/.inputrc"
-        - template: bash/colors.bashrc
-          filename: "{{ dotfiles_folder }}/colors.bashrc"
-          linkname: "~/.colors.bashrc"
-    - git_dotfiles:
-        - template: "git/gitconfig"
-          filename: "{{ dotfiles_folder }}/.gitconfig"
-          linkname: "~/.gitconfig"
-        - template: "git/gitignore_global"
-          filename: "{{ dotfiles_folder }}/.gitignore_global"
-          linkname: "~/.gitignore_global"
-        - template: "git/gitmessage"
-          filename: "{{ dotfiles_folder }}/.gitmessage"
-          linkname: "~/.gitmessage"
+    ignore_brew_errors: yes
+    current_user: "{{ lookup('env', 'USER') }}"
+    temp_folder: "/tmp/pimp_my_temp"
+    dotfiles_folder: "~/opt/dotfiles"
+    pip3_packages:
+      - PyYAML
+      - tldr
+      # - localstack
+    brew_repositories:
+      - homebrew/cask-fonts
+    brew_packages:
+      - ansible-lint
+      - autojump
+      - awscli
+      - bash
+      - fzf
+      - bash-completion
+      - bash-git-prompt
+      # - ccze   # have to comment since this package is gone
+      - coreutils
+      - docker-completion
+      # - docker-compose-completion # gone
+      - gh
+      - git
+      - gpg
+      - gradle-completion
+      - grc
+      - htop
+      - httpie
+      - jq
+      - k9s
+      - lynx
+      - maven
+      - maven-completion
+      - mc
+      - mdp
+      - micro
+      - most
+      - mtr
+      - nano
+      - ncdu
+      - nmap
+      - pip-completion
+      - pv
+      - tree
+      - watch
+      - wget
+      - yq
+      - diff-so-fancy
+      - hidetatz/tap/kubecolor
+      - bat
+      - exa
+      - lazygit
+      - lsd
+      - duf
+      - dust
+      - rs/tap/curlie
+      - eksctl
+      - pinentry-mac
+      - minikube
+      - rsync
+      - helm
+      - terraform
+      - jless
+      - ffmpeg
+      - glow
+      - tmux
+      - gnu-tar
+      - go
+      # - copyq
+      - kubectx
+      - moreutils # sponge is needed
+    brew_casks:
+      # - vagrant # do not need vagrant anymore
+      - font-hack-nerd-font
+      - firefox
+      - apptivate
+      - iterm2
+      - sourcetree
+      - visual-studio-code
+      - dozer
+      - jordanbaird-ice
+    vscode_extensions:
+      - aaron-bond.better-comments
+      - adammaras.overtype
+      - andyyaldoo.vscode-json # unescape/format json
+      - chrmarti.ssh
+      - coolbear.systemd-unit-file
+      - devmike.mikrotik-routeros-script
+      - efanzh.graphviz-preview
+      - esbenp.prettier-vscode
+      - fabiospampinato.vscode-todo-plus
+      - haaaad.ansible
+      - hashicorp.terraform
+      - hoovercj.vscode-power-mode
+      - kelvin.vscode-sshfs
+      - lamartire.git-indicators
+      - leodevbro.blockman
+      - marcostazi.vs-code-vagrantfile
+      - mrmlnc.vscode-apache
+      - mrmlnc.vscode-duplicate
+      - ms-azuretools.vscode-docker
+      - ms-kubernetes-tools.vscode-kubernetes-tools
+      - nobuhito.printcode
+      - qinjia.filenamecomplete
+      - redhat.vscode-yaml
+      - samverschueren.final-newline
+      - shanoor.vscode-nginx
+      - shardulm94.trailing-spaces
+      - stephanvs.dot
+      - timonwong.ansible-autocomplete
+      - wholroyd.jinja
+      - yzhang.markdown-all-in-one
+    vscode_extensions_disabled:
+      - freakone.cursoruler
+      - geeebe.duplicate
+      - james-yu.latex-workshop
+    bash_dotfiles:
+      - template: bash/bash.bashrc
+        filename: "{{ dotfiles_folder }}/.bash_profile"
+        linkname: "~/.bash_profile"
+      - template: bash/grc.bashrc
+        filename: "{{ dotfiles_folder }}/grc.bashrc"
+        linkname: "~/.grc.bashrc"
+      - template: bash/inputrc.bashrc
+        filename: "{{ dotfiles_folder }}/.inputrc"
+        linkname: "~/.inputrc"
+      - template: bash/colors.bashrc
+        filename: "{{ dotfiles_folder }}/colors.bashrc"
+        linkname: "~/.colors.bashrc"
+    git_dotfiles:
+      - template: "git/gitconfig"
+        filename: "{{ dotfiles_folder }}/.gitconfig"
+        linkname: "~/.gitconfig"
+      - template: "git/gitignore_global"
+        filename: "{{ dotfiles_folder }}/.gitignore_global"
+        linkname: "~/.gitignore_global"
+      - template: "git/gitmessage"
+        filename: "{{ dotfiles_folder }}/.gitmessage"
+        linkname: "~/.gitmessage"
 
 
   tasks:
@@ -396,6 +396,7 @@
             - name: Grab "kubectl completion bash" shell output
               command: kubectl completion bash
               register: kubectl_completion_content
+              changed_when: false
             - name: Put kubectl completion into its file
               blockinfile:
                 create: yes
@@ -505,9 +506,13 @@
         - name: Install enabled VSCode extensions
           command: "code --install-extension {{ item }}"
           loop: "{{ vscode_extensions }}"
-          ignore_errors: yes
+          register: vscode_install_result
+          failed_when: false
+          changed_when: vscode_install_result.rc == 0
 
         - name: Uninstall disabled VSCode extensions
           command: "code --uninstall-extension {{ item }}"
           loop: "{{ vscode_extensions_disabled }}"
-          ignore_errors: yes
+          register: vscode_uninstall_result
+          failed_when: false
+          changed_when: vscode_uninstall_result.rc == 0

--- a/playbook-init.yml
+++ b/playbook-init.yml
@@ -91,25 +91,6 @@
         - visual-studio-code
         - dozer
         - jordanbaird-ice
-    - dmg_files:
-        - name: Idea
-          url: https://download.jetbrains.com/idea/ideaIC-2019.3.4-jbr8.dmg
-          filename: ideaIC-2019.3.4-jbr8.dmg
-        - name: Telegram
-          url: https://telegram.org/dl/desktop/mac
-          filename: telegram_latest.dmg
-        - name: teamviewer
-        - name: VOX
-        - name: krita
-          website: https://krita.org/en/
-    - applications:
-        # - name: CheatSheet
-        #   url: https://www.mediaatelier.com/CheatSheet/
-        #   filename: tbd
-        # application gone, replacement needed
-        - name: Choosy
-          url: https://choosy.app/
-          filename: tbd
     - vscode_extentions:
         - aaron-bond.better-comments
         - adammaras.overtype
@@ -496,23 +477,6 @@
         value: "~/Documents/pictures/screenshots"
         state: present
 
-    - name: Download applications
-      tags: never
-      get_url:
-        url: "{{ item.url }}"
-        dest: "{{ temp_folder }}/{{ item.filename }}"
-      loop: "{{ applications }}"
-      loop_control:
-        label: "{{ item.name }}"
-
-    - name: Download dmg_files
-      tags: never
-      get_url:
-        url: "{{ item.url }}"
-        dest: "{{ temp_folder }}/{{ item.filename }}"
-      loop: "{{ dmg_files }}"
-      loop_control:
-        label: "{{ item.name }}"
 
     - name: Configure GitHub cli
       tags:

--- a/playbook-init.yml
+++ b/playbook-init.yml
@@ -1,15 +1,15 @@
 #!/usr/bin/env ANSIBLE_NOCOWS=1 ansible-playbook
-
+---
 - name: Pimp my mac
   hosts: localhost
   connection: local
-  gather_facts: yes
+  gather_facts: true
   vars_files:
     - "arch/{{ ansible_architecture }}.yaml"
   vars:
     # Set to `yes` so brew tasks do not abort the run for already-installed packages;
     # brew exits non-zero in that case, which would otherwise be treated as a failure.
-    ignore_brew_errors: yes
+    ignore_brew_errors: true
     current_user: "{{ lookup('env', 'USER') }}"
     temp_folder: "/tmp/pimp_my_temp"
     dotfiles_folder: "~/opt/dotfiles"
@@ -150,7 +150,6 @@
         filename: "{{ dotfiles_folder }}/.gitmessage"
         linkname: "~/.gitmessage"
 
-
   tasks:
     - name: Create needed folders
       tags:
@@ -159,7 +158,7 @@
       file:
         path: "{{ item }}"
         state: directory
-        mode: '750'
+        mode: "750"
       with_items:
         - "{{ temp_folder }}"
         - "~/develop"
@@ -217,7 +216,7 @@
         - projects_folders
       find:
         paths: projects
-        recurse: no
+        recurse: false
         file_type: any
       register: projects_folders
 
@@ -260,7 +259,7 @@
       file:
         path: "{{ dotfiles_folder }}/projects/{{ item.name }}"
         state: directory
-        mode: '750'
+        mode: "750"
       loop: "{{ projects_data }}"
       loop_control:
         label: "{{ item.name }}"
@@ -279,7 +278,7 @@
         - name: Ensure bash is set as user shell for user "{{ current_user }}"
           tags:
             - never
-          become: yes
+          become: true
           user:
             name: "{{ current_user }}"
             shell: /bin/bash
@@ -344,7 +343,6 @@
             state: present
           loop: "{{ (combined_brew_casks | community.general.json_query('results[*].msg') | flatten) | unique | sort }}"
 
-
     - name: Populate bash profile
       tags: bash
       block:
@@ -356,7 +354,7 @@
           template:
             src: "{{ item.bashrc }}"
             dest: "{{ dotfiles_folder }}/projects/{{ item.name }}/project.bashrc"
-            mode: '644'
+            mode: "644"
           loop: "{{ projects_data }}"
           when: item.bashrc
           loop_control:
@@ -366,20 +364,20 @@
           template:
             src: "{{ item.template }}"
             dest: "{{ item.filename }}"
-            mode: '644'
+            mode: "644"
           with_items: "{{ bash_dotfiles }}"
 
         - name: Bash history
           copy:
             content: ""
             dest: "{{ dotfiles_folder }}/.bash_history"
-            force: no
-            mode: '644'
+            force: false
+            mode: "644"
 
         - name: Link bash dotfiles
           file:
             state: link
-            force: yes
+            force: true
             src: "{{ item.filename }}"
             dest: "{{ item.linkname }}"
           with_items:
@@ -399,7 +397,7 @@
               changed_when: false
             - name: Put kubectl completion into its file
               blockinfile:
-                create: yes
+                create: true
                 path: "{{ bash_completion_dir }}/kubectl"
                 block: "{{ kubectl_completion_content.stdout }}"
 
@@ -410,7 +408,7 @@
           template:
             src: "{{ item.gitconfig }}"
             dest: "{{ dotfiles_folder }}/projects/{{ item.name }}/gitconfig"
-            mode: '644'
+            mode: "644"
           loop: "{{ projects_data }}"
           when: item.gitconfig
           loop_control:
@@ -420,13 +418,13 @@
           template:
             src: "{{ item.template }}"
             dest: "{{ item.filename }}"
-            mode: '644'
+            mode: "644"
           with_items: "{{ git_dotfiles }}"
 
         - name: Link git dotfiles
           file:
             state: link
-            force: yes
+            force: true
             src: "{{ item.filename }}"
             dest: "{{ item.linkname }}"
           with_items:
@@ -440,8 +438,8 @@
             - gpg
           ansible.builtin.lineinfile:
             path: ~/.gnupg/gpg.conf
-            line: 'use-agent'
-            create: yes
+            line: "use-agent"
+            create: true
 
         - name: GPG configuration (x86)
           tags:
@@ -449,8 +447,8 @@
             - gpg
           ansible.builtin.lineinfile:
             path: ~/.gnupg/gpg-agent.conf
-            line: 'pinentry-program /usr/local/bin/pinentry-tty'
-            create: yes
+            line: "pinentry-program /usr/local/bin/pinentry-tty"
+            create: true
           when: ansible_architecture == 'x86_64'
 
         - name: GPG configuration (arm)
@@ -459,10 +457,9 @@
             - gpg
           ansible.builtin.lineinfile:
             path: ~/.gnupg/gpg-agent.conf
-            line: 'pinentry-program /opt/homebrew/bin/pinentry-tty'
-            create: yes
+            line: "pinentry-program /opt/homebrew/bin/pinentry-tty"
+            create: true
           when: ansible_architecture == 'arm64'
-
 
     - name: Configure ssh
       tags:
@@ -488,14 +485,13 @@
         value: "~/Documents/pictures/screenshots"
         state: present
 
-
     - name: Configure GitHub cli
       tags:
         - gh
       template:
         src: "gh/config.yml"
         dest: ~/.config/gh/config.yml
-        mode: '600'
+        mode: "600"
 
     - name: Manage VSCode extensions
       # Requires VSCode to already be installed (brew_casks runs first under the brew tag).

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - name: community.general


### PR DESCRIPTION
## Summary

- Fix typos: `ignore_brew_errors` (5 occurrences), `brew_casks` tag, `configuration` in README, `vscode_extensions` throughout
- Replace dead `dmg_files`/`applications` variable blocks and their `never`-tagged download tasks with proper brew casks in the personal project
      (`telegram`, `teamviewer`, `vox`, `choosy`, `keyclu`)
- Move GUI apps misplaced in `brew_packages` → `brew_casks` (`dbeaver-community`, `google-chrome`, `keepassxc`, `vlc`, `xnviewmp`)
- Add Ansible task to install/uninstall VSCode extensions via `code --install-extension`, tagged `vscode_extensions`
- Rewrite Makefile: all 9 targets in `.PHONY`, complete `make help` output, new `vscode_extensions` target
- Expand README with full `projects/` pattern reference: file table, `project_vars.yaml` schema, minimal example
- Add inline comments to playbook: project discovery chain, `never` tag convention, `ignore_brew_errors` rationale

## Test plan

- [x] `make help` lists all targets
- [x] `ansible-lint playbook-init.yml` passes with no new warnings
- [x] `make brew` installs packages without errors
- [ ] `make vscode_extensions` installs extensions on a machine with VSCode present
- [x] `grep -rn "ignore_brew_erorrs\|brew_cascs\|vscode_extentions\|/Users/disfinder" playbook-init.yml Makefile README.md` returns no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)")
